### PR TITLE
feat(rds) - RDS 인스턴스 세팅 및 Bastion Host 설정

### DIFF
--- a/lib/dife-cloud-stack.js
+++ b/lib/dife-cloud-stack.js
@@ -1,5 +1,6 @@
 const { Stack } = require('aws-cdk-lib');
-const { Vpc, SubnetType } = require('aws-cdk-lib/aws-ec2');
+const { Vpc, SubnetType, InstanceType, InstanceClass, InstanceSize, MachineImage } = require('aws-cdk-lib/aws-ec2');
+const { DatabaseInstance, DatabaseInstanceEngine, MysqlEngineVersion } = require('aws-cdk-lib/aws-rds');
 const { Construct } = require('constructs');
 
 
@@ -27,6 +28,27 @@ class DifeCloudStack extends Stack {
           subnetType: SubnetType.PRIVATE_ISOLATED,
         }
       ]
+    });
+
+    const rdsInstance = new DatabaseInstance(this, 'DifeRDS', {
+      engine: DatabaseInstanceEngine.mysql({
+        version: MysqlEngineVersion.VER_8_0,
+      }),
+      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+      vpc,
+      vpcSubnets: {
+        subnetType: SubnetType.PRIVATE_ISOLATED,
+      },
+      deletionProtection: true, 
+    });
+
+    const bastion = new Instance(this, 'DifeBastionHost', {
+      instanceType: new InstanceType('t3.micro'),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      vpc,
+      vpcSubnets: {
+        subnetType: SubnetType.PUBLIC,
+      },
     });
   }
 }


### PR DESCRIPTION
### 개요

- 관계형 DB인 RDS의 인스턴스 배포
  - MySQL 8.0 버전 사용
  - Free Tier 범위인 t3.micro 타입 사용
  - 정보 보호를 위해 Private Subnet에 배치

- Bastion Server 서버 생성 필요
  - Bastion Server는 Private Subnet에 배치된 RDS에 로컬에서 접근할 때 필요한 서버이다
  - 최근 버전의 Amazon Linux 사용
  - SSH로 외부에서 접근이 필요하므로 Public Subnet에 배치